### PR TITLE
Add progress callback support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,9 +629,9 @@ checksum = "cf5a574dadd7941adeaa71823ecba5e28331b8313fb2e1c6a5c7e5981ea53ad6"
 
 [[package]]
 name = "nod"
-version = "2.0.0-alpha.1"
+version = "2.0.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "570c7973ba795b0e3e0ca2822d05cc26aa79da29a95f15862f02940e1801be3e"
+checksum = "90bd6308e3103a186ae7e830e421813965c3f7e2122903286d3a80ac6d09d643"
 dependencies = [
  "adler",
  "aes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "A Rust utility to replicate wbfs_file 2.9 functionality for conve
 license = "GPL-2.0-only"
 
 [dependencies]
-nod = "2.0.0-alpha.1"
+nod = "2.0.0-alpha.2"
 clap = { version = "4.5", features = ["derive", "color"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,7 +67,13 @@ fn run_conversion(options: &Options) -> Result<()> {
 
     // Call the library's main conversion function.
     // It now internally handles whether the disc is a Wii or GameCube image.
-    iso2wbfs::convert(&options.input_file, &options.output_directory)?;
+    iso2wbfs::convert(
+        &options.input_file,
+        &options.output_directory,
+        |_progress, _total| {
+            // TODO: Implement a progress bar
+        },
+    )?;
 
     tracing::info!("Conversion completed successfully.");
     Ok(())


### PR DESCRIPTION
This PR does a few things:
- Update nod to v2.0.0-alpha.2 to fix a regression reading lossless WBFS/CISOs.
- Add a progress callback parameter to convert, so we can display nice progress in the UI.
- Updates the thread selection logic, I've found this threading selection works pretty well.
- Enables calculating CRC32/SHA1/XXH64 hashes, so that they're stored in the disc images with NKit metadata.